### PR TITLE
Explicit tsconfig with rule for catching possibly 'undefined'

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions" : {
+    "exactOptionalPropertyTypes": true,
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
Current TSlint setup relies on implicit IDE settings which are may be different. So by adding explict TSConfig with rules may help mitigate those differences and provide a more level playground.

Reason for this PR: Webstorm's default TSLint fails to pick up `TS2532: Object is possibly 'undefined'`
Tested on Webstorm 2023.1 (both Mac & Win)