### PR TITLE
Refactor createUser helper

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
 export type User = {
-  games: Games;
+  games: Partial<Games>;
   membershipLevel: string;
   yearsActive: number;
 }
 
 export type Games = {
-  won?: number;
-  lost?: number;
-  draw?: number;
-  forfeited?: number;
+  won: number;
+  lost: number;
+  draw: number;
+  forfeited: number;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,9 +1,11 @@
 import { getUserRating } from '../src/index';
-import { Games, User } from '../src/types';
+import { User } from '../src/types';
 
 // create a user with years an an active player
 // games won, lost, draw
-const createUser = (user: Partial<User> = {}, games: Games = {}) => {
+const createUser = (user: Partial<User> = {}) => {
+  const games = user.games || {};
+
   return Object.assign({
     username: 'chessman',
     yearsActive: 0,
@@ -57,10 +59,12 @@ describe('getUserRating', () => {
 
   // new feature
   it.skip('give 1 extra point per 10 games played', () => {
-    const user = createUser({}, {
-      won: 3, // 9 points
-      lost: 1, // -1 point
-      draw: 6, // + 6
+    const user = createUser({
+      games: {
+        won: 3, // 9 points
+        lost: 1, // -1 point
+        draw: 6, // + 6
+      }
     }); // + 1 for 10 games
 
     expect(getUserRating(user)).toBe(15);


### PR DESCRIPTION
This updates our `createUser` helper to allow a `games` property to be passed in the first param that doesn't get ignored. While I was at it, I also updated our `Games` type so the properties are non-optional, but the `User` type can now have an incomplete Game object. This feels truer to our real APIs; instead of `{ forfeited: undefined }`, we're much more likely to simply have the key omitted in a JSON response. 