### PR TITLE
So long, chessman

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Chess has a function `getUserRating` that determines a user's rating, calculated
 
 ```ts
 {
-  username: 'chessman',
   yearsActive: 0,
   membershipLevel: 'free', // could be 'free', 'bronze', 'silver', and 'gold'
   games: {
@@ -58,7 +57,6 @@ Based off the above criteria and the given user, this method call should return 
 
 ```ts
 const userRating = getUserRating({
-  username: 'chessman',
   yearsActive: 1, // 1 point
   membershipLevel: 'silver', // 2 points
   games: {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,7 +5,6 @@ const createUser = (user: Partial<User> = {}) => {
   const games = user.games || {};
 
   return Object.assign({
-    username: 'chessman',
     yearsActive: 0,
     membershipLevel: 'free', // bronze, silver, gold
   },
@@ -30,7 +29,7 @@ describe('getUserRating', () => {
   });
 
   describe('test score based on yearsActive', () => {
-    it('a user should get 1 point for the first year active', () => {
+    it('a user should get 1 point for the. first year active', () => {
       const user = createUser({
         yearsActive: 1,
       });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,7 +29,7 @@ describe('getUserRating', () => {
   });
 
   describe('test score based on yearsActive', () => {
-    it('a user should get 1 point for the. first year active', () => {
+    it('a user should get 1 point for the first year active', () => {
       const user = createUser({
         yearsActive: 1,
       });


### PR DESCRIPTION
It's natural to paste in the sample code of a `user` object into a `createUser()` call, but the latter takes a `Partial<User>`, which doesn't contain a username, resulting in a TS error. The username is a bit wooden and doesn't really contribute to the code readability / understandability, so we’re opting to just remove it. 